### PR TITLE
Fix Inconsistent scrollbar

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -75,6 +75,7 @@ nav{
     border-radius: 30px;
     bottom: 20px;
     opacity: 0.8;
+    overflow: hidden; /*required to hide the scrollbar overflow due to rounded corners*/
 }
 
 .stores-list{
@@ -182,25 +183,25 @@ nav{
 /*scroll bar styling */
 
 /* width */
-::-webkit-scrollbar {
+/* ::-webkit-scrollbar {
     width: 15px;
     scroll-margin: 50px 0 0 50px;
 
-  }
+  } */
   
   /* Track */
-  ::-webkit-scrollbar-track {
+/*   ::-webkit-scrollbar-track {
     border-radius: 10px;
-  }
+  } */
    
   /* Handle */
-  ::-webkit-scrollbar-thumb {
+/*   ::-webkit-scrollbar-thumb {
     background: rgb(0, 0, 0); 
     border-radius: 10px;
     
-  }
+  } */
   
   /* Handle on hover */
-  ::-webkit-scrollbar-thumb:hover {
+/*   ::-webkit-scrollbar-thumb:hover {
     background: #444242; 
-  }
+  } */


### PR DESCRIPTION
Comment the duplicate code causing the issue.

Add `overflow: hidden` to `store-list-container` to hide the scrollbar overflow due to rounded corners.

Fixes : #8 